### PR TITLE
Add Exasol benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,11 @@ run-polars-gpu-no-env: run-polars-no-env data/tables/ ## Run Polars CPU and GPU 
 
 .PHONY: run-duckdb
 run-duckdb: .venv data/tables/.generated ## Run DuckDB benchmarks
-	$(VENV_BIN)/python -m queries.duckdb
+       $(VENV_BIN)/python -m queries.duckdb
+
+.PHONY: run-exasol
+run-exasol: .venv ## Run Exasol benchmarks
+	$(VENV_BIN)/python -m queries.exasol
 
 .PHONY: run-pandas
 run-pandas: .venv data/tables/.generated ## Run pandas benchmarks
@@ -111,7 +115,7 @@ run-modin: .venv data/tables/.generated ## Run Modin benchmarks
 	$(VENV_BIN)/python -m queries.modin
 
 .PHONY: run-all
-run-all: run-polars run-duckdb run-pandas run-pyspark run-dask run-modin  ## Run all benchmarks
+run-all: run-polars run-duckdb run-exasol run-pandas run-pyspark run-dask run-modin  ## Run all benchmarks
 
 .PHONY: plot
 plot: .venv  ## Plot results

--- a/queries/exasol/__main__.py
+++ b/queries/exasol/__main__.py
@@ -1,0 +1,4 @@
+from queries.common_utils import execute_all
+
+if __name__ == "__main__":
+    execute_all("exasol")

--- a/queries/exasol/q1.py
+++ b/queries/exasol/q1.py
@@ -1,0 +1,40 @@
+
+from queries.exasol import utils
+
+Q_NUM = 1
+
+
+def q() -> None:
+    lineitem = utils.get_line_item_ds()
+
+    query_str = f"""
+    select
+        l_returnflag,
+        l_linestatus,
+        sum(l_quantity) as sum_qty,
+        sum(l_extendedprice) as sum_base_price,
+        sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+        sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+        avg(l_quantity) as avg_qty,
+        avg(l_extendedprice) as avg_price,
+        avg(l_discount) as avg_disc,
+        count(*) as count_order
+    from
+        {lineitem}
+    where
+        l_shipdate <= '1998-09-02'
+    group by
+        l_returnflag,
+        l_linestatus
+    order by
+        l_returnflag,
+        l_linestatus
+    """
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q10.py
+++ b/queries/exasol/q10.py
@@ -1,0 +1,54 @@
+
+from queries.exasol import utils
+
+Q_NUM = 10
+
+
+def q() -> None:
+    customer_ds = utils.get_customer_ds()
+    orders_ds = utils.get_orders_ds()
+    line_item_ds = utils.get_line_item_ds()
+    nation_ds = utils.get_nation_ds()
+
+    query_str = f"""
+    select
+        c_custkey,
+        c_name,
+        round(sum(l_extendedprice * (1 - l_discount)), 2) as revenue,
+        c_acctbal,
+        n_name,
+        c_address,
+        c_phone,
+        c_comment
+    from
+        {customer_ds},
+        {orders_ds},
+        {line_item_ds},
+        {nation_ds}
+    where
+        c_custkey = o_custkey
+        and l_orderkey = o_orderkey
+        and o_orderdate >= date '1993-10-01'
+        and o_orderdate < date '1993-10-01' + interval '3' month
+        and l_returnflag = 'R'
+        and c_nationkey = n_nationkey
+    group by
+        c_custkey,
+        c_name,
+        c_acctbal,
+        c_phone,
+        n_name,
+        c_address,
+        c_comment
+    order by
+        revenue desc
+    limit 20
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q11.py
+++ b/queries/exasol/q11.py
@@ -1,0 +1,48 @@
+
+from queries.exasol import utils
+
+Q_NUM = 11
+
+
+def q() -> None:
+    supplier_ds = utils.get_supplier_ds()
+    part_supp_ds = utils.get_part_supp_ds()
+    nation_ds = utils.get_nation_ds()
+
+    query_str = f"""
+    select
+        ps_partkey,
+        round(sum(ps_supplycost * ps_availqty), 2) as value
+    from
+        {part_supp_ds},
+        {supplier_ds},
+        {nation_ds}
+    where
+        ps_suppkey = s_suppkey
+        and s_nationkey = n_nationkey
+        and n_name = 'GERMANY'
+    group by
+        ps_partkey having
+                sum(ps_supplycost * ps_availqty) > (
+            select
+                sum(ps_supplycost * ps_availqty) * 0.0001
+            from
+                {part_supp_ds},
+                {supplier_ds},
+                {nation_ds}
+            where
+                ps_suppkey = s_suppkey
+                and s_nationkey = n_nationkey
+                and n_name = 'GERMANY'
+            )
+        order by
+            value desc
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q12.py
+++ b/queries/exasol/q12.py
@@ -1,0 +1,47 @@
+
+from queries.exasol import utils
+
+Q_NUM = 12
+
+
+def q() -> None:
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+
+    query_str = f"""
+    select
+        l_shipmode,
+        sum(case
+            when o_orderpriority = '1-URGENT'
+                or o_orderpriority = '2-HIGH'
+                then 1
+            else 0
+        end) as high_line_count,
+        sum(case
+            when o_orderpriority <> '1-URGENT'
+                and o_orderpriority <> '2-HIGH'
+                then 1
+            else 0
+        end) as low_line_count
+    from
+        {orders_ds},
+        {line_item_ds}
+    where
+        o_orderkey = l_orderkey
+        and l_shipmode in ('MAIL', 'SHIP')
+        and l_commitdate < l_receiptdate
+        and l_shipdate < l_commitdate
+        and l_receiptdate >= date '1994-01-01'
+        and l_receiptdate < date '1994-01-01' + interval '1' year
+    group by
+        l_shipmode
+    order by
+        l_shipmode
+	"""
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q13.py
+++ b/queries/exasol/q13.py
@@ -1,0 +1,41 @@
+
+from queries.exasol import utils
+
+Q_NUM = 13
+
+
+def q() -> None:
+    orders_ds = utils.get_orders_ds()
+    customer_ds = utils.get_customer_ds()
+
+    query_str = f"""
+    select
+        c_count, count(*) as custdist
+    from (
+        select
+            c_custkey,
+            count(o_orderkey)
+        from
+            {customer_ds} left outer join {orders_ds} on
+            c_custkey = o_custkey
+            and o_comment not like '%special%requests%'
+        group by
+            c_custkey
+        )as c_orders (c_custkey, c_count)
+    group by
+        c_count
+    order by
+        custdist desc,
+        c_count desc
+	"""
+
+    utils.get_customer_ds()
+    utils.get_orders_ds()
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q14.py
+++ b/queries/exasol/q14.py
@@ -1,0 +1,33 @@
+
+from queries.exasol import utils
+
+Q_NUM = 14
+
+
+def q() -> None:
+    part_ds = utils.get_part_ds()
+    line_item_ds = utils.get_line_item_ds()
+
+    query_str = f"""
+    select
+        round(100.00 * sum(case
+            when p_type like 'PROMO%'
+                then l_extendedprice * (1 - l_discount)
+            else 0
+        end) / sum(l_extendedprice * (1 - l_discount)), 2) as promo_revenue
+    from
+        {line_item_ds},
+        {part_ds}
+    where
+        l_partkey = p_partkey
+        and l_shipdate >= date '1995-09-01'
+        and l_shipdate < date '1995-09-01' + interval '1' month
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q15.py
+++ b/queries/exasol/q15.py
@@ -1,0 +1,55 @@
+
+from queries.exasol import utils
+
+Q_NUM = 15
+
+
+def q() -> None:
+    line_item_ds = utils.get_line_item_ds()
+    supplier_ds = utils.get_supplier_ds()
+
+    ddl = f"""
+    create or replace temporary view revenue (supplier_no, total_revenue) as
+        select
+            l_suppkey,
+            sum(l_extendedprice * (1 - l_discount))
+        from
+            {line_item_ds}
+        where
+            l_shipdate >= date '1996-01-01'
+            and l_shipdate < date '1996-01-01' + interval '3' month
+        group by
+            l_suppkey
+    """
+
+    query_str = f"""
+    select
+        s_suppkey,
+        s_name,
+        s_address,
+        s_phone,
+        total_revenue
+    from
+        {supplier_ds},
+        revenue
+    where
+        s_suppkey = supplier_no
+        and total_revenue = (
+            select
+                max(total_revenue)
+            from
+                revenue
+        )
+    order by
+        s_suppkey
+	"""
+
+    _ = duckdb.execute(ddl)
+
+
+    utils.run_query(Q_NUM, query_str)
+    duckdb.execute("DROP VIEW IF EXISTS revenue")
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q16.py
+++ b/queries/exasol/q16.py
@@ -1,0 +1,51 @@
+
+from queries.exasol import utils
+
+Q_NUM = 16
+
+
+def q() -> None:
+    part_ds = utils.get_part_ds()
+    supplier_ds = utils.get_supplier_ds()
+    part_supp_ds = utils.get_part_supp_ds()
+
+    query_str = f"""
+    select
+        p_brand,
+        p_type,
+        p_size,
+        count(distinct ps_suppkey) as supplier_cnt
+    from
+        {part_supp_ds},
+        {part_ds}
+    where
+        p_partkey = ps_partkey
+        and p_brand <> 'Brand#45'
+        and p_type not like 'MEDIUM POLISHED%'
+        and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+        and ps_suppkey not in (
+            select
+                s_suppkey
+            from
+                {supplier_ds}
+            where
+                s_comment like '%Customer%Complaints%'
+        )
+    group by
+        p_brand,
+        p_type,
+        p_size
+    order by
+        supplier_cnt desc,
+        p_brand,
+        p_type,
+        p_size
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q17.py
+++ b/queries/exasol/q17.py
@@ -1,0 +1,37 @@
+
+from queries.exasol import utils
+
+Q_NUM = 17
+
+
+def q() -> None:
+    part_ds = utils.get_part_ds()
+    line_item_ds = utils.get_line_item_ds()
+
+    query_str = f"""
+    select
+        round(sum(l_extendedprice) / 7.0, 2) as avg_yearly
+    from
+        {line_item_ds},
+        {part_ds}
+    where
+        p_partkey = l_partkey
+        and p_brand = 'Brand#23'
+        and p_container = 'MED BOX'
+        and l_quantity < (
+            select
+                0.2 * avg(l_quantity)
+            from
+                {line_item_ds}
+            where
+                l_partkey = p_partkey
+        )
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q18.py
+++ b/queries/exasol/q18.py
@@ -1,0 +1,54 @@
+
+from queries.exasol import utils
+
+Q_NUM = 18
+
+
+def q() -> None:
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+    customer_ds = utils.get_customer_ds()
+
+    query_str = f"""
+    select
+        c_name,
+        c_custkey,
+        o_orderkey,
+        o_orderdate as o_orderdat,
+        o_totalprice,
+        sum(l_quantity) as col6
+    from
+        {customer_ds},
+        {orders_ds},
+        {line_item_ds}
+    where
+        o_orderkey in (
+            select
+                l_orderkey
+            from
+                {line_item_ds}
+            group by
+                l_orderkey having
+                    sum(l_quantity) > 300
+        )
+        and c_custkey = o_custkey
+        and o_orderkey = l_orderkey
+    group by
+        c_name,
+        c_custkey,
+        o_orderkey,
+        o_orderdate,
+        o_totalprice
+    order by
+        o_totalprice desc,
+        o_orderdate
+    limit 100
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q19.py
+++ b/queries/exasol/q19.py
@@ -1,0 +1,55 @@
+
+from queries.exasol import utils
+
+Q_NUM = 19
+
+
+def q() -> None:
+    part_ds = utils.get_part_ds()
+    line_item_ds = utils.get_line_item_ds()
+
+    query_str = f"""
+    select
+        round(sum(l_extendedprice* (1 - l_discount)), 2) as revenue
+    from
+        {line_item_ds},
+        {part_ds}
+    where
+        (
+            p_partkey = l_partkey
+            and p_brand = 'Brand#12'
+            and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+            and l_quantity >= 1 and l_quantity <= 1 + 10
+            and p_size between 1 and 5
+            and l_shipmode in ('AIR', 'AIR REG')
+            and l_shipinstruct = 'DELIVER IN PERSON'
+        )
+        or
+        (
+            p_partkey = l_partkey
+            and p_brand = 'Brand#23'
+            and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+            and l_quantity >= 10 and l_quantity <= 20
+            and p_size between 1 and 10
+            and l_shipmode in ('AIR', 'AIR REG')
+            and l_shipinstruct = 'DELIVER IN PERSON'
+        )
+        or
+        (
+            p_partkey = l_partkey
+            and p_brand = 'Brand#34'
+            and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+            and l_quantity >= 20 and l_quantity <= 30
+            and p_size between 1 and 15
+            and l_shipmode in ('AIR', 'AIR REG')
+            and l_shipinstruct = 'DELIVER IN PERSON'
+        )
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q2.py
+++ b/queries/exasol/q2.py
@@ -1,0 +1,67 @@
+
+from queries.exasol import utils
+
+Q_NUM = 2
+
+
+def q() -> None:
+    region_ds = utils.get_region_ds()
+    nation_ds = utils.get_nation_ds()
+    supplier_ds = utils.get_supplier_ds()
+    part_ds = utils.get_part_ds()
+    part_supp_ds = utils.get_part_supp_ds()
+
+    query_str = f"""
+    select
+        s_acctbal,
+        s_name,
+        n_name,
+        p_partkey,
+        p_mfgr,
+        s_address,
+        s_phone,
+        s_comment
+    from
+        {part_ds},
+        {supplier_ds},
+        {part_supp_ds},
+        {nation_ds},
+        {region_ds}
+    where
+        p_partkey = ps_partkey
+        and s_suppkey = ps_suppkey
+        and p_size = 15
+        and p_type like '%BRASS'
+        and s_nationkey = n_nationkey
+        and n_regionkey = r_regionkey
+        and r_name = 'EUROPE'
+        and ps_supplycost = (
+            select
+                min(ps_supplycost)
+            from
+                {part_supp_ds},
+                {supplier_ds},
+                {nation_ds},
+                {region_ds}
+            where
+                p_partkey = ps_partkey
+                and s_suppkey = ps_suppkey
+                and s_nationkey = n_nationkey
+                and n_regionkey = r_regionkey
+                and r_name = 'EUROPE'
+        )
+    order by
+        s_acctbal desc,
+        n_name,
+        s_name,
+        p_partkey
+    limit 100
+    """
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q20.py
+++ b/queries/exasol/q20.py
@@ -1,0 +1,60 @@
+
+from queries.exasol import utils
+
+Q_NUM = 20
+
+
+def q() -> None:
+    line_item_ds = utils.get_line_item_ds()
+    nation_ds = utils.get_nation_ds()
+    supplier_ds = utils.get_supplier_ds()
+    part_ds = utils.get_part_ds()
+    part_supp_ds = utils.get_part_supp_ds()
+
+    query_str = f"""
+    select
+        s_name,
+        s_address
+    from
+        {supplier_ds},
+        {nation_ds}
+    where
+        s_suppkey in (
+            select
+                ps_suppkey
+            from
+                {part_supp_ds}
+            where
+                ps_partkey in (
+                    select
+                        p_partkey
+                    from
+                        {part_ds}
+                    where
+                        p_name like 'forest%'
+                )
+                and ps_availqty > (
+                    select
+                        0.5 * sum(l_quantity)
+                    from
+                        {line_item_ds}
+                    where
+                        l_partkey = ps_partkey
+                        and l_suppkey = ps_suppkey
+                        and l_shipdate >= date '1994-01-01'
+                        and l_shipdate < date '1994-01-01' + interval '1' year
+                )
+        )
+        and s_nationkey = n_nationkey
+        and n_name = 'CANADA'
+    order by
+        s_name
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q21.py
+++ b/queries/exasol/q21.py
@@ -1,0 +1,62 @@
+
+from queries.exasol import utils
+
+Q_NUM = 21
+
+
+def q() -> None:
+    line_item_ds = utils.get_line_item_ds()
+    supplier_ds = utils.get_supplier_ds()
+    nation_ds = utils.get_nation_ds()
+    orders_ds = utils.get_orders_ds()
+
+    query_str = f"""
+    select
+        s_name,
+        count(*) as numwait
+    from
+        {supplier_ds},
+        {line_item_ds} l1,
+        {orders_ds},
+        {nation_ds}
+    where
+        s_suppkey = l1.l_suppkey
+        and o_orderkey = l1.l_orderkey
+        and o_orderstatus = 'F'
+        and l1.l_receiptdate > l1.l_commitdate
+        and exists (
+            select
+                *
+            from
+                {line_item_ds} l2
+            where
+                l2.l_orderkey = l1.l_orderkey
+                and l2.l_suppkey <> l1.l_suppkey
+        )
+        and not exists (
+            select
+                *
+            from
+                {line_item_ds} l3
+            where
+                l3.l_orderkey = l1.l_orderkey
+                and l3.l_suppkey <> l1.l_suppkey
+                and l3.l_receiptdate > l3.l_commitdate
+        )
+        and s_nationkey = n_nationkey
+        and n_name = 'SAUDI ARABIA'
+    group by
+        s_name
+    order by
+        numwait desc,
+        s_name
+    limit 100
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q22.py
+++ b/queries/exasol/q22.py
@@ -1,0 +1,56 @@
+
+from queries.exasol import utils
+
+Q_NUM = 22
+
+
+def q() -> None:
+    orders_ds = utils.get_orders_ds()
+    customer_ds = utils.get_customer_ds()
+
+    query_str = f"""
+    select
+        cntrycode,
+        count(*) as numcust,
+        sum(c_acctbal) as totacctbal
+    from (
+        select
+            substring(c_phone from 1 for 2) as cntrycode,
+            c_acctbal
+        from
+            {customer_ds}
+        where
+            substring(c_phone from 1 for 2) in
+                (13, 31, 23, 29, 30, 18, 17)
+            and c_acctbal > (
+                select
+                    avg(c_acctbal)
+                from
+                    {customer_ds}
+                where
+                    c_acctbal > 0.00
+                    and substring (c_phone from 1 for 2) in
+                        (13, 31, 23, 29, 30, 18, 17)
+            )
+            and not exists (
+                select
+                    *
+                from
+                    {orders_ds}
+                where
+                    o_custkey = c_custkey
+            )
+        ) as custsale
+    group by
+        cntrycode
+    order by
+        cntrycode
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q3.py
+++ b/queries/exasol/q3.py
@@ -1,0 +1,44 @@
+
+from queries.exasol import utils
+
+Q_NUM = 3
+
+
+def q() -> None:
+    customer_ds = utils.get_customer_ds()
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+
+    query_str = f"""
+    select
+        l_orderkey,
+        sum(l_extendedprice * (1 - l_discount)) as revenue,
+        o_orderdate,
+        o_shippriority
+    from
+        {customer_ds},
+        {orders_ds},
+        {line_item_ds}
+    where
+        c_mktsegment = 'BUILDING'
+        and c_custkey = o_custkey
+        and l_orderkey = o_orderkey
+        and o_orderdate < '1995-03-15'
+        and l_shipdate > '1995-03-15'
+    group by
+        l_orderkey,
+        o_orderdate,
+        o_shippriority
+    order by
+        revenue desc,
+        o_orderdate
+    limit 10
+    """
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q4.py
+++ b/queries/exasol/q4.py
@@ -1,0 +1,41 @@
+
+from queries.exasol import utils
+
+Q_NUM = 4
+
+
+def q() -> None:
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+
+    query_str = f"""
+    select
+        o_orderpriority,
+        count(*) as order_count
+    from
+        {orders_ds}
+    where
+        o_orderdate >= timestamp '1993-07-01'
+        and o_orderdate < timestamp '1993-07-01' + interval '3' month
+        and exists (
+            select
+                *
+            from
+                {line_item_ds}
+            where
+                l_orderkey = o_orderkey
+                and l_commitdate < l_receiptdate
+        )
+    group by
+        o_orderpriority
+    order by
+        o_orderpriority
+    """
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q5.py
+++ b/queries/exasol/q5.py
@@ -1,0 +1,48 @@
+
+from queries.exasol import utils
+
+Q_NUM = 5
+
+
+def q() -> None:
+    region_ds = utils.get_region_ds()
+    nation_ds = utils.get_nation_ds()
+    customer_ds = utils.get_customer_ds()
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+    supplier_ds = utils.get_supplier_ds()
+
+    query_str = f"""
+    select
+        n_name,
+        sum(l_extendedprice * (1 - l_discount)) as revenue
+    from
+        {customer_ds},
+        {orders_ds},
+        {line_item_ds},
+        {supplier_ds},
+        {nation_ds},
+        {region_ds}
+    where
+        c_custkey = o_custkey
+        and l_orderkey = o_orderkey
+        and l_suppkey = s_suppkey
+        and c_nationkey = s_nationkey
+        and s_nationkey = n_nationkey
+        and n_regionkey = r_regionkey
+        and r_name = 'ASIA'
+        and o_orderdate >= timestamp '1994-01-01'
+        and o_orderdate < timestamp '1994-01-01' + interval '1' year
+    group by
+        n_name
+    order by
+        revenue desc
+    """
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q6.py
+++ b/queries/exasol/q6.py
@@ -1,0 +1,28 @@
+
+from queries.exasol import utils
+
+Q_NUM = 6
+
+
+def q() -> None:
+    line_item_ds = utils.get_line_item_ds()
+
+    query_str = f"""
+    select
+        sum(l_extendedprice * l_discount) as revenue
+    from
+        {line_item_ds}
+    where
+        l_shipdate >= timestamp '1994-01-01'
+        and l_shipdate < timestamp '1994-01-01' + interval '1' year
+        and l_discount between .06 - 0.01 and .06 + 0.01
+        and l_quantity < 24
+    """
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q7.py
+++ b/queries/exasol/q7.py
@@ -1,0 +1,62 @@
+
+from queries.exasol import utils
+
+Q_NUM = 7
+
+
+def q() -> None:
+    nation_ds = utils.get_nation_ds()
+    customer_ds = utils.get_customer_ds()
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+    supplier_ds = utils.get_supplier_ds()
+
+    query_str = f"""
+    select
+        supp_nation,
+        cust_nation,
+        l_year,
+        sum(volume) as revenue
+    from
+        (
+            select
+                n1.n_name as supp_nation,
+                n2.n_name as cust_nation,
+                year(l_shipdate) as l_year,
+                l_extendedprice * (1 - l_discount) as volume
+            from
+                {supplier_ds},
+                {line_item_ds},
+                {orders_ds},
+                {customer_ds},
+                {nation_ds} n1,
+                {nation_ds} n2
+            where
+                s_suppkey = l_suppkey
+                and o_orderkey = l_orderkey
+                and c_custkey = o_custkey
+                and s_nationkey = n1.n_nationkey
+                and c_nationkey = n2.n_nationkey
+                and (
+                    (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+                    or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
+                )
+                and l_shipdate between timestamp '1995-01-01' and timestamp '1996-12-31'
+        ) as shipping
+    group by
+        supp_nation,
+        cust_nation,
+        l_year
+    order by
+        supp_nation,
+        cust_nation,
+        l_year
+    """
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q8.py
+++ b/queries/exasol/q8.py
@@ -1,0 +1,64 @@
+
+from queries.exasol import utils
+
+Q_NUM = 8
+
+
+def q() -> None:
+    part_ds = utils.get_part_ds()
+    supplier_ds = utils.get_supplier_ds()
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+    customer_ds = utils.get_customer_ds()
+    nation_ds = utils.get_nation_ds()
+    region_ds = utils.get_region_ds()
+
+    query_str = f"""
+    select
+        o_year,
+        round(
+            sum(case
+                when nation = 'BRAZIL' then volume
+                else 0
+            end) / sum(volume)
+        , 2) as mkt_share
+    from
+        (
+            select
+                extract(year from o_orderdate) as o_year,
+                l_extendedprice * (1 - l_discount) as volume,
+                n2.n_name as nation
+            from
+                {part_ds},
+                {supplier_ds},
+                {line_item_ds},
+                {orders_ds},
+                {customer_ds},
+                {nation_ds} n1,
+                {nation_ds} n2,
+                {region_ds}
+            where
+                p_partkey = l_partkey
+                and s_suppkey = l_suppkey
+                and l_orderkey = o_orderkey
+                and o_custkey = c_custkey
+                and c_nationkey = n1.n_nationkey
+                and n1.n_regionkey = r_regionkey
+                and r_name = 'AMERICA'
+                and s_nationkey = n2.n_nationkey
+                and o_orderdate between timestamp '1995-01-01' and timestamp '1996-12-31'
+                and p_type = 'ECONOMY ANODIZED STEEL'
+        ) as all_nations
+    group by
+        o_year
+    order by
+        o_year
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/q9.py
+++ b/queries/exasol/q9.py
@@ -1,0 +1,56 @@
+
+from queries.exasol import utils
+
+Q_NUM = 9
+
+
+def q() -> None:
+    part_ds = utils.get_part_ds()
+    supplier_ds = utils.get_supplier_ds()
+    line_item_ds = utils.get_line_item_ds()
+    orders_ds = utils.get_orders_ds()
+    part_supp_ds = utils.get_part_supp_ds()
+    nation_ds = utils.get_nation_ds()
+
+    query_str = f"""
+    select
+        nation,
+        o_year,
+        round(sum(amount), 2) as sum_profit
+    from
+        (
+            select
+                n_name as nation,
+                year(o_orderdate) as o_year,
+                l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+            from
+                {part_ds},
+                {supplier_ds},
+                {line_item_ds},
+                {part_supp_ds},
+                {orders_ds},
+                {nation_ds}
+            where
+                s_suppkey = l_suppkey
+                and ps_suppkey = l_suppkey
+                and ps_partkey = l_partkey
+                and p_partkey = l_partkey
+                and o_orderkey = l_orderkey
+                and s_nationkey = n_nationkey
+                and p_name like '%green%'
+        ) as profit
+    group by
+        nation,
+        o_year
+    order by
+        nation,
+        o_year desc
+	"""
+
+
+
+    utils.run_query(Q_NUM, query_str)
+
+
+if __name__ == "__main__":
+    q()

--- a/queries/exasol/utils.py
+++ b/queries/exasol/utils.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pandas as pd
+import pyexasol
+
+from queries.common_utils import check_query_result_pd, run_query_generic
+from settings import Settings
+
+settings = Settings()
+
+_connection: pyexasol.ExaConnection | None = None
+
+
+def get_connection() -> pyexasol.ExaConnection:
+    global _connection
+    if _connection is None:
+        dsn = f"{settings.exasol.host}:{settings.exasol.port}"
+        _connection = pyexasol.connect(
+            dsn=dsn,
+            user=settings.exasol.user,
+            password=settings.exasol.password,
+            schema=settings.exasol.schema,
+        )
+    return _connection
+
+
+def get_line_item_ds() -> str:
+    return "lineitem"
+
+
+def get_orders_ds() -> str:
+    return "orders"
+
+
+def get_customer_ds() -> str:
+    return "customer"
+
+
+def get_region_ds() -> str:
+    return "region"
+
+
+def get_nation_ds() -> str:
+    return "nation"
+
+
+def get_supplier_ds() -> str:
+    return "supplier"
+
+
+def get_part_ds() -> str:
+    return "part"
+
+
+def get_part_supp_ds() -> str:
+    return "partsupp"
+
+
+def run_query(query_number: int, query: str) -> None:
+    conn = get_connection()
+
+    def execute() -> pd.DataFrame:
+        return conn.export_to_pandas(query)
+
+    run_query_generic(
+        execute,
+        query_number,
+        "exasol",
+        library_version=pyexasol.__version__,
+        query_checker=check_query_result_pd,
+    )

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ tpchgen-cli
 dask[dataframe]
 dask-expr
 duckdb
+pyexasol
 modin[ray]
 pandas>=2.0
 polars

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,6 +174,8 @@ toolz==1.0.0
     #   partd
 tpchgen-cli==1.1.0
     # via -r requirements.in
+pyexasol==0.25.1
+    # via -r requirements.in
 typing-extensions==4.13.2
     # via
     #   pydantic

--- a/settings.py
+++ b/settings.py
@@ -75,12 +75,32 @@ class Plot(BaseSettings):
     )
 
 
+class Exasol(BaseSettings):
+    host: str = "localhost"
+    port: int = 8563
+    user: str = "sys"
+    password: str = "exasol"
+    schema: str = "tpch"
+
+    model_config = SettingsConfigDict(
+        env_prefix="exasol_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def dsn(self) -> str:
+        return f"{self.host}:{self.port}"
+
+
 class Settings(BaseSettings):
     scale_factor: float = 1.0
 
     paths: Paths = Paths()
     plot: Plot = Plot()
     run: Run = Run()
+    exasol: Exasol = Exasol()
 
     @computed_field  # type: ignore[prop-decorator]
     @property


### PR DESCRIPTION
## Summary
- add Exasol SQL benchmark modules similar to DuckDB
- add Exasol settings and new run target
- include pyexasol dependency

## Testing
- `ruff check queries/exasol settings.py Makefile requirements.in requirements.txt`
- `mypy queries/exasol settings.py` *(fails: Error importing plugin "pydantic.mypy")*
- `pytest -q`
