### PR TITLE
Use official TPC‑H SQL for Exasol

### DIFF
--- a/queries/exasol/q1.py
+++ b/queries/exasol/q1.py
@@ -1,40 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 1
 
 
 def q() -> None:
-    lineitem = utils.get_line_item_ds()
-
-    query_str = f"""
-    select
-        l_returnflag,
-        l_linestatus,
-        sum(l_quantity) as sum_qty,
-        sum(l_extendedprice) as sum_base_price,
-        sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
-        sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
-        avg(l_quantity) as avg_qty,
-        avg(l_extendedprice) as avg_price,
-        avg(l_discount) as avg_disc,
-        count(*) as count_order
-    from
-        {lineitem}
-    where
-        l_shipdate <= '1998-09-02'
-    group by
-        l_returnflag,
-        l_linestatus
-    order by
-        l_returnflag,
-        l_linestatus
-    """
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q10.py
+++ b/queries/exasol/q10.py
@@ -1,54 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 10
 
 
 def q() -> None:
-    customer_ds = utils.get_customer_ds()
-    orders_ds = utils.get_orders_ds()
-    line_item_ds = utils.get_line_item_ds()
-    nation_ds = utils.get_nation_ds()
-
-    query_str = f"""
-    select
-        c_custkey,
-        c_name,
-        round(sum(l_extendedprice * (1 - l_discount)), 2) as revenue,
-        c_acctbal,
-        n_name,
-        c_address,
-        c_phone,
-        c_comment
-    from
-        {customer_ds},
-        {orders_ds},
-        {line_item_ds},
-        {nation_ds}
-    where
-        c_custkey = o_custkey
-        and l_orderkey = o_orderkey
-        and o_orderdate >= date '1993-10-01'
-        and o_orderdate < date '1993-10-01' + interval '3' month
-        and l_returnflag = 'R'
-        and c_nationkey = n_nationkey
-    group by
-        c_custkey,
-        c_name,
-        c_acctbal,
-        c_phone,
-        n_name,
-        c_address,
-        c_comment
-    order by
-        revenue desc
-    limit 20
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q11.py
+++ b/queries/exasol/q11.py
@@ -1,48 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 11
 
 
 def q() -> None:
-    supplier_ds = utils.get_supplier_ds()
-    part_supp_ds = utils.get_part_supp_ds()
-    nation_ds = utils.get_nation_ds()
-
-    query_str = f"""
-    select
-        ps_partkey,
-        round(sum(ps_supplycost * ps_availqty), 2) as value
-    from
-        {part_supp_ds},
-        {supplier_ds},
-        {nation_ds}
-    where
-        ps_suppkey = s_suppkey
-        and s_nationkey = n_nationkey
-        and n_name = 'GERMANY'
-    group by
-        ps_partkey having
-                sum(ps_supplycost * ps_availqty) > (
-            select
-                sum(ps_supplycost * ps_availqty) * 0.0001
-            from
-                {part_supp_ds},
-                {supplier_ds},
-                {nation_ds}
-            where
-                ps_suppkey = s_suppkey
-                and s_nationkey = n_nationkey
-                and n_name = 'GERMANY'
-            )
-        order by
-            value desc
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q12.py
+++ b/queries/exasol/q12.py
@@ -1,47 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 12
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-
-    query_str = f"""
-    select
-        l_shipmode,
-        sum(case
-            when o_orderpriority = '1-URGENT'
-                or o_orderpriority = '2-HIGH'
-                then 1
-            else 0
-        end) as high_line_count,
-        sum(case
-            when o_orderpriority <> '1-URGENT'
-                and o_orderpriority <> '2-HIGH'
-                then 1
-            else 0
-        end) as low_line_count
-    from
-        {orders_ds},
-        {line_item_ds}
-    where
-        o_orderkey = l_orderkey
-        and l_shipmode in ('MAIL', 'SHIP')
-        and l_commitdate < l_receiptdate
-        and l_shipdate < l_commitdate
-        and l_receiptdate >= date '1994-01-01'
-        and l_receiptdate < date '1994-01-01' + interval '1' year
-    group by
-        l_shipmode
-    order by
-        l_shipmode
-	"""
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q13.py
+++ b/queries/exasol/q13.py
@@ -1,41 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 13
 
 
 def q() -> None:
-    orders_ds = utils.get_orders_ds()
-    customer_ds = utils.get_customer_ds()
-
-    query_str = f"""
-    select
-        c_count, count(*) as custdist
-    from (
-        select
-            c_custkey,
-            count(o_orderkey)
-        from
-            {customer_ds} left outer join {orders_ds} on
-            c_custkey = o_custkey
-            and o_comment not like '%special%requests%'
-        group by
-            c_custkey
-        )as c_orders (c_custkey, c_count)
-    group by
-        c_count
-    order by
-        custdist desc,
-        c_count desc
-	"""
-
-    utils.get_customer_ds()
-    utils.get_orders_ds()
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q14.py
+++ b/queries/exasol/q14.py
@@ -1,33 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 14
 
 
 def q() -> None:
-    part_ds = utils.get_part_ds()
-    line_item_ds = utils.get_line_item_ds()
-
-    query_str = f"""
-    select
-        round(100.00 * sum(case
-            when p_type like 'PROMO%'
-                then l_extendedprice * (1 - l_discount)
-            else 0
-        end) / sum(l_extendedprice * (1 - l_discount)), 2) as promo_revenue
-    from
-        {line_item_ds},
-        {part_ds}
-    where
-        l_partkey = p_partkey
-        and l_shipdate >= date '1995-09-01'
-        and l_shipdate < date '1995-09-01' + interval '1' month
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q15.py
+++ b/queries/exasol/q15.py
@@ -1,55 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 15
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds()
-    supplier_ds = utils.get_supplier_ds()
-
-    ddl = f"""
-    create or replace temporary view revenue (supplier_no, total_revenue) as
-        select
-            l_suppkey,
-            sum(l_extendedprice * (1 - l_discount))
-        from
-            {line_item_ds}
-        where
-            l_shipdate >= date '1996-01-01'
-            and l_shipdate < date '1996-01-01' + interval '3' month
-        group by
-            l_suppkey
-    """
-
-    query_str = f"""
-    select
-        s_suppkey,
-        s_name,
-        s_address,
-        s_phone,
-        total_revenue
-    from
-        {supplier_ds},
-        revenue
-    where
-        s_suppkey = supplier_no
-        and total_revenue = (
-            select
-                max(total_revenue)
-            from
-                revenue
-        )
-    order by
-        s_suppkey
-	"""
-
-    _ = duckdb.execute(ddl)
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
-    duckdb.execute("DROP VIEW IF EXISTS revenue")
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q16.py
+++ b/queries/exasol/q16.py
@@ -1,51 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 16
 
 
 def q() -> None:
-    part_ds = utils.get_part_ds()
-    supplier_ds = utils.get_supplier_ds()
-    part_supp_ds = utils.get_part_supp_ds()
-
-    query_str = f"""
-    select
-        p_brand,
-        p_type,
-        p_size,
-        count(distinct ps_suppkey) as supplier_cnt
-    from
-        {part_supp_ds},
-        {part_ds}
-    where
-        p_partkey = ps_partkey
-        and p_brand <> 'Brand#45'
-        and p_type not like 'MEDIUM POLISHED%'
-        and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
-        and ps_suppkey not in (
-            select
-                s_suppkey
-            from
-                {supplier_ds}
-            where
-                s_comment like '%Customer%Complaints%'
-        )
-    group by
-        p_brand,
-        p_type,
-        p_size
-    order by
-        supplier_cnt desc,
-        p_brand,
-        p_type,
-        p_size
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q17.py
+++ b/queries/exasol/q17.py
@@ -1,37 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 17
 
 
 def q() -> None:
-    part_ds = utils.get_part_ds()
-    line_item_ds = utils.get_line_item_ds()
-
-    query_str = f"""
-    select
-        round(sum(l_extendedprice) / 7.0, 2) as avg_yearly
-    from
-        {line_item_ds},
-        {part_ds}
-    where
-        p_partkey = l_partkey
-        and p_brand = 'Brand#23'
-        and p_container = 'MED BOX'
-        and l_quantity < (
-            select
-                0.2 * avg(l_quantity)
-            from
-                {line_item_ds}
-            where
-                l_partkey = p_partkey
-        )
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q18.py
+++ b/queries/exasol/q18.py
@@ -1,54 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 18
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-    customer_ds = utils.get_customer_ds()
-
-    query_str = f"""
-    select
-        c_name,
-        c_custkey,
-        o_orderkey,
-        o_orderdate as o_orderdat,
-        o_totalprice,
-        sum(l_quantity) as col6
-    from
-        {customer_ds},
-        {orders_ds},
-        {line_item_ds}
-    where
-        o_orderkey in (
-            select
-                l_orderkey
-            from
-                {line_item_ds}
-            group by
-                l_orderkey having
-                    sum(l_quantity) > 300
-        )
-        and c_custkey = o_custkey
-        and o_orderkey = l_orderkey
-    group by
-        c_name,
-        c_custkey,
-        o_orderkey,
-        o_orderdate,
-        o_totalprice
-    order by
-        o_totalprice desc,
-        o_orderdate
-    limit 100
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q19.py
+++ b/queries/exasol/q19.py
@@ -1,55 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 19
 
 
 def q() -> None:
-    part_ds = utils.get_part_ds()
-    line_item_ds = utils.get_line_item_ds()
-
-    query_str = f"""
-    select
-        round(sum(l_extendedprice* (1 - l_discount)), 2) as revenue
-    from
-        {line_item_ds},
-        {part_ds}
-    where
-        (
-            p_partkey = l_partkey
-            and p_brand = 'Brand#12'
-            and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
-            and l_quantity >= 1 and l_quantity <= 1 + 10
-            and p_size between 1 and 5
-            and l_shipmode in ('AIR', 'AIR REG')
-            and l_shipinstruct = 'DELIVER IN PERSON'
-        )
-        or
-        (
-            p_partkey = l_partkey
-            and p_brand = 'Brand#23'
-            and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
-            and l_quantity >= 10 and l_quantity <= 20
-            and p_size between 1 and 10
-            and l_shipmode in ('AIR', 'AIR REG')
-            and l_shipinstruct = 'DELIVER IN PERSON'
-        )
-        or
-        (
-            p_partkey = l_partkey
-            and p_brand = 'Brand#34'
-            and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
-            and l_quantity >= 20 and l_quantity <= 30
-            and p_size between 1 and 15
-            and l_shipmode in ('AIR', 'AIR REG')
-            and l_shipinstruct = 'DELIVER IN PERSON'
-        )
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q2.py
+++ b/queries/exasol/q2.py
@@ -1,67 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 2
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds()
-    nation_ds = utils.get_nation_ds()
-    supplier_ds = utils.get_supplier_ds()
-    part_ds = utils.get_part_ds()
-    part_supp_ds = utils.get_part_supp_ds()
-
-    query_str = f"""
-    select
-        s_acctbal,
-        s_name,
-        n_name,
-        p_partkey,
-        p_mfgr,
-        s_address,
-        s_phone,
-        s_comment
-    from
-        {part_ds},
-        {supplier_ds},
-        {part_supp_ds},
-        {nation_ds},
-        {region_ds}
-    where
-        p_partkey = ps_partkey
-        and s_suppkey = ps_suppkey
-        and p_size = 15
-        and p_type like '%BRASS'
-        and s_nationkey = n_nationkey
-        and n_regionkey = r_regionkey
-        and r_name = 'EUROPE'
-        and ps_supplycost = (
-            select
-                min(ps_supplycost)
-            from
-                {part_supp_ds},
-                {supplier_ds},
-                {nation_ds},
-                {region_ds}
-            where
-                p_partkey = ps_partkey
-                and s_suppkey = ps_suppkey
-                and s_nationkey = n_nationkey
-                and n_regionkey = r_regionkey
-                and r_name = 'EUROPE'
-        )
-    order by
-        s_acctbal desc,
-        n_name,
-        s_name,
-        p_partkey
-    limit 100
-    """
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q20.py
+++ b/queries/exasol/q20.py
@@ -1,60 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 20
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds()
-    nation_ds = utils.get_nation_ds()
-    supplier_ds = utils.get_supplier_ds()
-    part_ds = utils.get_part_ds()
-    part_supp_ds = utils.get_part_supp_ds()
-
-    query_str = f"""
-    select
-        s_name,
-        s_address
-    from
-        {supplier_ds},
-        {nation_ds}
-    where
-        s_suppkey in (
-            select
-                ps_suppkey
-            from
-                {part_supp_ds}
-            where
-                ps_partkey in (
-                    select
-                        p_partkey
-                    from
-                        {part_ds}
-                    where
-                        p_name like 'forest%'
-                )
-                and ps_availqty > (
-                    select
-                        0.5 * sum(l_quantity)
-                    from
-                        {line_item_ds}
-                    where
-                        l_partkey = ps_partkey
-                        and l_suppkey = ps_suppkey
-                        and l_shipdate >= date '1994-01-01'
-                        and l_shipdate < date '1994-01-01' + interval '1' year
-                )
-        )
-        and s_nationkey = n_nationkey
-        and n_name = 'CANADA'
-    order by
-        s_name
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q21.py
+++ b/queries/exasol/q21.py
@@ -1,62 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 21
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds()
-    supplier_ds = utils.get_supplier_ds()
-    nation_ds = utils.get_nation_ds()
-    orders_ds = utils.get_orders_ds()
-
-    query_str = f"""
-    select
-        s_name,
-        count(*) as numwait
-    from
-        {supplier_ds},
-        {line_item_ds} l1,
-        {orders_ds},
-        {nation_ds}
-    where
-        s_suppkey = l1.l_suppkey
-        and o_orderkey = l1.l_orderkey
-        and o_orderstatus = 'F'
-        and l1.l_receiptdate > l1.l_commitdate
-        and exists (
-            select
-                *
-            from
-                {line_item_ds} l2
-            where
-                l2.l_orderkey = l1.l_orderkey
-                and l2.l_suppkey <> l1.l_suppkey
-        )
-        and not exists (
-            select
-                *
-            from
-                {line_item_ds} l3
-            where
-                l3.l_orderkey = l1.l_orderkey
-                and l3.l_suppkey <> l1.l_suppkey
-                and l3.l_receiptdate > l3.l_commitdate
-        )
-        and s_nationkey = n_nationkey
-        and n_name = 'SAUDI ARABIA'
-    group by
-        s_name
-    order by
-        numwait desc,
-        s_name
-    limit 100
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q22.py
+++ b/queries/exasol/q22.py
@@ -1,56 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 22
 
 
 def q() -> None:
-    orders_ds = utils.get_orders_ds()
-    customer_ds = utils.get_customer_ds()
-
-    query_str = f"""
-    select
-        cntrycode,
-        count(*) as numcust,
-        sum(c_acctbal) as totacctbal
-    from (
-        select
-            substring(c_phone from 1 for 2) as cntrycode,
-            c_acctbal
-        from
-            {customer_ds}
-        where
-            substring(c_phone from 1 for 2) in
-                (13, 31, 23, 29, 30, 18, 17)
-            and c_acctbal > (
-                select
-                    avg(c_acctbal)
-                from
-                    {customer_ds}
-                where
-                    c_acctbal > 0.00
-                    and substring (c_phone from 1 for 2) in
-                        (13, 31, 23, 29, 30, 18, 17)
-            )
-            and not exists (
-                select
-                    *
-                from
-                    {orders_ds}
-                where
-                    o_custkey = c_custkey
-            )
-        ) as custsale
-    group by
-        cntrycode
-    order by
-        cntrycode
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q3.py
+++ b/queries/exasol/q3.py
@@ -1,44 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 3
 
 
 def q() -> None:
-    customer_ds = utils.get_customer_ds()
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-
-    query_str = f"""
-    select
-        l_orderkey,
-        sum(l_extendedprice * (1 - l_discount)) as revenue,
-        o_orderdate,
-        o_shippriority
-    from
-        {customer_ds},
-        {orders_ds},
-        {line_item_ds}
-    where
-        c_mktsegment = 'BUILDING'
-        and c_custkey = o_custkey
-        and l_orderkey = o_orderkey
-        and o_orderdate < '1995-03-15'
-        and l_shipdate > '1995-03-15'
-    group by
-        l_orderkey,
-        o_orderdate,
-        o_shippriority
-    order by
-        revenue desc,
-        o_orderdate
-    limit 10
-    """
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q4.py
+++ b/queries/exasol/q4.py
@@ -1,41 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 4
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-
-    query_str = f"""
-    select
-        o_orderpriority,
-        count(*) as order_count
-    from
-        {orders_ds}
-    where
-        o_orderdate >= timestamp '1993-07-01'
-        and o_orderdate < timestamp '1993-07-01' + interval '3' month
-        and exists (
-            select
-                *
-            from
-                {line_item_ds}
-            where
-                l_orderkey = o_orderkey
-                and l_commitdate < l_receiptdate
-        )
-    group by
-        o_orderpriority
-    order by
-        o_orderpriority
-    """
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q5.py
+++ b/queries/exasol/q5.py
@@ -1,48 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 5
 
 
 def q() -> None:
-    region_ds = utils.get_region_ds()
-    nation_ds = utils.get_nation_ds()
-    customer_ds = utils.get_customer_ds()
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-    supplier_ds = utils.get_supplier_ds()
-
-    query_str = f"""
-    select
-        n_name,
-        sum(l_extendedprice * (1 - l_discount)) as revenue
-    from
-        {customer_ds},
-        {orders_ds},
-        {line_item_ds},
-        {supplier_ds},
-        {nation_ds},
-        {region_ds}
-    where
-        c_custkey = o_custkey
-        and l_orderkey = o_orderkey
-        and l_suppkey = s_suppkey
-        and c_nationkey = s_nationkey
-        and s_nationkey = n_nationkey
-        and n_regionkey = r_regionkey
-        and r_name = 'ASIA'
-        and o_orderdate >= timestamp '1994-01-01'
-        and o_orderdate < timestamp '1994-01-01' + interval '1' year
-    group by
-        n_name
-    order by
-        revenue desc
-    """
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q6.py
+++ b/queries/exasol/q6.py
@@ -1,28 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 6
 
 
 def q() -> None:
-    line_item_ds = utils.get_line_item_ds()
-
-    query_str = f"""
-    select
-        sum(l_extendedprice * l_discount) as revenue
-    from
-        {line_item_ds}
-    where
-        l_shipdate >= timestamp '1994-01-01'
-        and l_shipdate < timestamp '1994-01-01' + interval '1' year
-        and l_discount between .06 - 0.01 and .06 + 0.01
-        and l_quantity < 24
-    """
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q7.py
+++ b/queries/exasol/q7.py
@@ -1,62 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 7
 
 
 def q() -> None:
-    nation_ds = utils.get_nation_ds()
-    customer_ds = utils.get_customer_ds()
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-    supplier_ds = utils.get_supplier_ds()
-
-    query_str = f"""
-    select
-        supp_nation,
-        cust_nation,
-        l_year,
-        sum(volume) as revenue
-    from
-        (
-            select
-                n1.n_name as supp_nation,
-                n2.n_name as cust_nation,
-                year(l_shipdate) as l_year,
-                l_extendedprice * (1 - l_discount) as volume
-            from
-                {supplier_ds},
-                {line_item_ds},
-                {orders_ds},
-                {customer_ds},
-                {nation_ds} n1,
-                {nation_ds} n2
-            where
-                s_suppkey = l_suppkey
-                and o_orderkey = l_orderkey
-                and c_custkey = o_custkey
-                and s_nationkey = n1.n_nationkey
-                and c_nationkey = n2.n_nationkey
-                and (
-                    (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
-                    or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
-                )
-                and l_shipdate between timestamp '1995-01-01' and timestamp '1996-12-31'
-        ) as shipping
-    group by
-        supp_nation,
-        cust_nation,
-        l_year
-    order by
-        supp_nation,
-        cust_nation,
-        l_year
-    """
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q8.py
+++ b/queries/exasol/q8.py
@@ -1,64 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 8
 
 
 def q() -> None:
-    part_ds = utils.get_part_ds()
-    supplier_ds = utils.get_supplier_ds()
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-    customer_ds = utils.get_customer_ds()
-    nation_ds = utils.get_nation_ds()
-    region_ds = utils.get_region_ds()
-
-    query_str = f"""
-    select
-        o_year,
-        round(
-            sum(case
-                when nation = 'BRAZIL' then volume
-                else 0
-            end) / sum(volume)
-        , 2) as mkt_share
-    from
-        (
-            select
-                extract(year from o_orderdate) as o_year,
-                l_extendedprice * (1 - l_discount) as volume,
-                n2.n_name as nation
-            from
-                {part_ds},
-                {supplier_ds},
-                {line_item_ds},
-                {orders_ds},
-                {customer_ds},
-                {nation_ds} n1,
-                {nation_ds} n2,
-                {region_ds}
-            where
-                p_partkey = l_partkey
-                and s_suppkey = l_suppkey
-                and l_orderkey = o_orderkey
-                and o_custkey = c_custkey
-                and c_nationkey = n1.n_nationkey
-                and n1.n_regionkey = r_regionkey
-                and r_name = 'AMERICA'
-                and s_nationkey = n2.n_nationkey
-                and o_orderdate between timestamp '1995-01-01' and timestamp '1996-12-31'
-                and p_type = 'ECONOMY ANODIZED STEEL'
-        ) as all_nations
-    group by
-        o_year
-    order by
-        o_year
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/q9.py
+++ b/queries/exasol/q9.py
@@ -1,56 +1,13 @@
-
 from queries.exasol import utils
 
 Q_NUM = 9
 
 
 def q() -> None:
-    part_ds = utils.get_part_ds()
-    supplier_ds = utils.get_supplier_ds()
-    line_item_ds = utils.get_line_item_ds()
-    orders_ds = utils.get_orders_ds()
-    part_supp_ds = utils.get_part_supp_ds()
-    nation_ds = utils.get_nation_ds()
-
-    query_str = f"""
-    select
-        nation,
-        o_year,
-        round(sum(amount), 2) as sum_profit
-    from
-        (
-            select
-                n_name as nation,
-                year(o_orderdate) as o_year,
-                l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
-            from
-                {part_ds},
-                {supplier_ds},
-                {line_item_ds},
-                {part_supp_ds},
-                {orders_ds},
-                {nation_ds}
-            where
-                s_suppkey = l_suppkey
-                and ps_suppkey = l_suppkey
-                and ps_partkey = l_partkey
-                and p_partkey = l_partkey
-                and o_orderkey = l_orderkey
-                and s_nationkey = n_nationkey
-                and p_name like '%green%'
-        ) as profit
-    group by
-        nation,
-        o_year
-    order by
-        nation,
-        o_year desc
-	"""
-
-
-
+    query_str = utils.get_sql_query(Q_NUM)
     utils.run_query(Q_NUM, query_str)
 
 
 if __name__ == "__main__":
     q()
+

--- a/queries/exasol/utils.py
+++ b/queries/exasol/utils.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
-import pandas as pd
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pyexasol
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from queries.common_utils import check_query_result_pd, run_query_generic
 from settings import Settings
@@ -9,6 +15,53 @@ from settings import Settings
 settings = Settings()
 
 _connection: pyexasol.ExaConnection | None = None
+_queries: dict[int, str] | None = None
+
+
+def _load_queries() -> dict[int, str]:
+    """Parse the bundled `queries.txt` file.
+
+    Return a mapping of query number to SQL.
+    """
+    path = Path(__file__).parent / "queries" / "queries.txt"
+    lines = path.read_text().splitlines()
+    pattern = re.compile(r"\* TPC-H Query (\d+) 0 \*")
+    queries: dict[int, str] = {}
+
+    i = 0
+    while i < len(lines):
+        m = pattern.match(lines[i].strip())
+        if m:
+            qnum = int(m.group(1))
+            i += 1
+            # skip preamble lines
+            while i < len(lines):
+                line = lines[i].strip()
+                if not line or line.startswith(("--", "*")):
+                    i += 1
+                    continue
+                break
+            query_lines = []
+            while i < len(lines):
+                line_text = lines[i].rstrip()
+                query_lines.append(line_text)
+                if line_text.endswith(";"):
+                    i += 1
+                    break
+                i += 1
+            queries[qnum] = "\n".join(query_lines)
+        else:
+            i += 1
+
+    return queries
+
+
+def get_sql_query(query_number: int) -> str:
+    """Return the SQL for the given query number parsed from `queries.txt`."""
+    global _queries
+    if _queries is None:
+        _queries = _load_queries()
+    return _queries[query_number]
 
 
 def get_connection() -> pyexasol.ExaConnection:


### PR DESCRIPTION
## Summary
- rework all Exasol query modules to read the official SQL
- parse `queries.txt` to load the original queries

## Testing
- `ruff check .`
- `mypy queries/exasol/utils.py` *(fails: Error importing plugin "pydantic.mypy")*

------
https://chatgpt.com/codex/tasks/task_b_685ab7b65a088320951f042757440de2